### PR TITLE
Makefile: respect environment CFLAGS, LDFLAGS, and CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@
 # <dragorn> make is a twisted beast
 ##################################
 LDLIBS		= -lpcap
-CFLAGS		= -pipe -Wall -D_LINUX -D_OPENSSL_MD4
+CFLAGS		+= -D_LINUX -D_OPENSSL_MD4
+LDFLAGS		?=
 LDLIBS		+= -lcrypto
-CFLAGS		+= -g3 #-ggdb -g
 PROGOBJ		= asleap.o genkeys.o utils.o common.o sha1.o
 PROG		= asleap genkeys
 #CC		    = clang-10
-CC          = gcc
+CC          ?= gcc
 PREFIX		?= /usr
 BINDIR		?= $(PREFIX)/bin
 DESTDIR		?=
@@ -32,10 +32,10 @@ sha1: sha1.c sha1.h
 
 asleap: asleap.c asleap.h sha1.o common.o common.h utils.o version.h sha1.c \
 	sha1.h 
-	$(CC) $(CFLAGS) asleap.c -o asleap common.o utils.o sha1.o $(LDLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) asleap.c -o asleap common.o utils.o sha1.o $(LDLIBS)
 
 genkeys: genkeys.c md4.c md4.h common.o utils.o version.h common.h
-	$(CC) $(CFLAGS) md4.c genkeys.c -o genkeys common.o utils.o $(LDLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) md4.c genkeys.c -o genkeys common.o utils.o $(LDLIBS)
 
 install: $(PROG)
 	install -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
## Problem

The Makefile uses `=` for `CFLAGS` and `CC`, which silently overwrites
whatever the build environment passes in.  Distribution build systems
(Gentoo, Buildroot, Yocto, cross-compilation setups) all set these
variables in the environment before invoking `make`, so they lose their
hardening flags, optimisation levels, sysroot paths, and custom
compilers entirely.

Additionally `-g3` (debug info) is unconditionally baked into release
builds, which bloats the binaries and is unexpected behaviour for
packagers.

## Changes

- `CFLAGS = …` → `CFLAGS += …` so environment flags are preserved;
  `-D_LINUX -D_OPENSSL_MD4` are appended on top.
- Drop forced `-pipe -Wall` (reasonable toolchain defaults; pass via
  the environment if desired).
- Drop `-g3` from the default build (use `CFLAGS=-g3 make` when
  debugging).
- Add `LDFLAGS ?=` and pass `$(LDFLAGS)` to both link steps so
  distributors can inject `-Wl,-z,relro`, `-Wl,-z,now`, etc.
- `CC = gcc` → `CC ?= gcc` so cross-compilers and `clang` work out
  of the box (`CC=aarch64-linux-gnu-gcc make`).

## Testing

Built cleanly with GCC 15 on Gentoo after applying this patch.