### PR TITLE
Makefile: add DOCDIR support to install/uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ PROG		= asleap genkeys
 CC          = gcc
 PREFIX		?= /usr
 BINDIR		?= $(PREFIX)/bin
+DOCDIR		?=
 DESTDIR		?=
 
 all: $(PROG) $(PROGOBJ)
@@ -40,9 +41,16 @@ genkeys: genkeys.c md4.c md4.h common.o utils.o version.h common.h
 install: $(PROG)
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(PROG) $(DESTDIR)$(BINDIR)
+ifdef DOCDIR
+	install -d $(DESTDIR)$(DOCDIR)
+	install -m 0644 README.md THANKS.md COMPILING.md COPYING $(DESTDIR)$(DOCDIR)
+endif
 
 uninstall:
 	$(RM) $(DESTDIR)$(BINDIR)/asleap $(DESTDIR)$(BINDIR)/genkeys
+ifdef DOCDIR
+	$(RM) -r $(DESTDIR)$(DOCDIR)
+endif
 
 clean:
 	$(RM) $(PROGOBJ) $(PROG) *~


### PR DESCRIPTION
## Problem

\`make install\` only installs the binaries.  Distributors (Gentoo,
Debian, Arch, etc.) and manual builds from source have no standard way
to install the documentation without patching the Makefile themselves.

## Changes

- Add \`DOCDIR ?=\` (empty by default) so doc installation is opt-in:
  pass \`DOCDIR\` explicitly to install documentation.

- Extend the \`install\` target with an \`ifdef DOCDIR\` guard that
  creates \`DOCDIR\` and installs \`README.md\`, \`THANKS.md\`,
  \`COMPILING.md\`, and \`COPYING\` into it when \`DOCDIR\` is set.

- Extend the \`uninstall\` target with the same guard to remove \`DOCDIR\`.

## Testing

```sh
# binaries only (default)
make install DESTDIR=/tmp/test
ls /tmp/test/usr/bin/          # asleap  genkeys

# binaries + docs
make install DESTDIR=/tmp/test DOCDIR=/usr/share/doc/asleap-2.4.1
ls /tmp/test/usr/share/doc/asleap-2.4.1/  # COMPILING.md  COPYING  README.md  THANKS.md

make uninstall DESTDIR=/tmp/test DOCDIR=/usr/share/doc/asleap-2.4.1
```